### PR TITLE
added media queries for ipad and phone

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -92,8 +92,12 @@ h3 {
   text-align: center;
 }
 
+.carousel-inner {
+  min-height: 670px;
+}
+
 .carousel-item {
-  padding: 8% 15% 0;
+  padding: 7% 15% 0;
 }
 
 h2 {
@@ -136,4 +140,23 @@ h2 {
 
 h5 {
   font-weight: bold;
+}
+
+/* Media queries */
+
+@media (max-width: 1070px) {
+  #title {
+    text-align: center;
+  }
+
+  .img-container {
+    width: 100%;
+    position: static;
+  }
+
+  .title-img {
+    padding-top: 20px;
+    position: static;
+    transform: rotate(0);
+  }
 }

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
           <a href="https://www.apple.com/app-store/" target="_blank" type="button" class="btn btn-dark btn-lg download-button"><i class="fa-brands fa-apple me-2"></i>Download</a>
           <a href="https://play.google.com/store/apps" target="_blank" type="button" class="btn btn-outline-light btn-lg download-button"><i class="fa-brands fa-google-play me-2"></i>Download</a>
         </div>
-        <div class="pt-3 col-lg-6">
+        <div class="pt-3 col-lg-6 img-container">
           <img class="ps-5 title-img" src="images/iphone8.png" alt="iphone-mockup">
         </div>
       </div>


### PR DESCRIPTION
title image is now after 1070 px or smaller not rotated and full screen + text is aligned center in title section